### PR TITLE
Remove WhatsApp notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+venv/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,41 @@
-# trading
+# TradingView Webhook Receiver
+
+This repository contains a minimal example of a server that receives webhook alerts from [TradingView](https://www.tradingview.com/).
+
+## Setup
+
+Create a virtual environment and install dependencies:
+
+```bash
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Running the server
+
+Start the Flask server:
+
+```bash
+python server.py
+```
+
+The server listens on port `5000` and exposes a single POST endpoint `/webhook` which expects JSON data. TradingView can be configured to send alerts to `http://<your-server-ip>:5000/webhook`.
+
+The endpoint forwards the alert to configured email addresses using SMTP. You
+can use Gmail or any other SMTP provider. Configuration is done through
+environment variables:
+
+- `ALERT_EMAILS`: comma separated list of recipient emails
+- `SMTP_SERVER`, `SMTP_PORT`, `SMTP_USERNAME`, `SMTP_PASSWORD`, `EMAIL_FROM`:
+  SMTP credentials for sending mail
+
+If any of the email variables are missing the message will not be sent.
+
+## Testing
+
+Run the automated tests with `pytest`:
+
+```bash
+pytest
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask==2.3.2
+Werkzeug<3.0
+pytest==7.4.0

--- a/server.py
+++ b/server.py
@@ -1,0 +1,44 @@
+import os
+import json
+import smtplib
+from email.mime.text import MIMEText
+from flask import Flask, request, jsonify
+
+EMAIL_RECIPIENTS = [e.strip() for e in os.getenv('ALERT_EMAILS', '').split(',') if e.strip()]
+
+app = Flask(__name__)
+
+
+def send_email(subject: str, body: str) -> None:
+    """Send an email using SMTP if configuration is present."""
+    if not EMAIL_RECIPIENTS:
+        return
+    smtp_server = os.getenv('SMTP_SERVER')
+    smtp_port = int(os.getenv('SMTP_PORT', '587'))
+    smtp_user = os.getenv('SMTP_USERNAME')
+    smtp_password = os.getenv('SMTP_PASSWORD')
+    email_from = os.getenv('EMAIL_FROM')
+    if not all([smtp_server, smtp_user, smtp_password, email_from]):
+        return
+
+    msg = MIMEText(body)
+    msg['Subject'] = subject
+    msg['From'] = email_from
+    msg['To'] = ', '.join(EMAIL_RECIPIENTS)
+
+    with smtplib.SMTP(smtp_server, smtp_port) as smtp:
+        smtp.starttls()
+        smtp.login(smtp_user, smtp_password)
+        smtp.sendmail(email_from, EMAIL_RECIPIENTS, msg.as_string())
+
+@app.route('/webhook', methods=['POST'])
+def webhook():
+    data = request.get_json(silent=True)
+    if data is None:
+        return jsonify({'error': 'Invalid JSON'}), 400
+    body = json.dumps(data)
+    send_email('TradingView Alert', body)
+    return jsonify({'received': data}), 200
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,13 @@
+import os
+import sys
+import pytest
+
+# ensure server module can be imported when tests are run from repo root
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from server import app
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    with app.test_client() as client:
+        yield client

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -1,0 +1,30 @@
+import json
+import server
+
+
+class Dummy:
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, *args, **kwargs):
+        self.calls.append((args, kwargs))
+
+
+def test_webhook(client, monkeypatch):
+    email_dummy = Dummy()
+    monkeypatch.setattr(server, "send_email", email_dummy)
+    response = client.post('/webhook', json={'foo': 'bar'})
+    assert response.status_code == 200
+    data = json.loads(response.data.decode())
+    assert data['received'] == {'foo': 'bar'}
+    assert email_dummy.calls, "send_email should be called"
+
+def test_webhook_echo(client):
+    response = client.post('/webhook', json={'foo': 'bar'})
+    assert response.status_code == 200
+    data = json.loads(response.data.decode())
+    assert data['received'] == {'foo': 'bar'}
+
+def test_invalid_json(client):
+    response = client.post('/webhook', data='notjson', headers={'Content-Type': 'application/json'})
+    assert response.status_code == 400


### PR DESCRIPTION
## Summary
- drop Twilio integration and WhatsApp alerts
- simplify README configuration notes for email only
- remove Twilio requirement
- update tests accordingly

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68483864f4588330bad3dd0b1b7b327b