### PR TITLE
Remove email notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+venv/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,35 @@
-# trading
+# TradingView Webhook Receiver
+
+This repository contains a minimal example of a server that receives webhook alerts from [TradingView](https://www.tradingview.com/).
+
+## Setup
+
+Create a virtual environment and install dependencies:
+
+```bash
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Running the server
+
+Start the Flask server:
+
+```bash
+python server.py
+```
+
+The server listens on port `5000` and exposes a single POST endpoint `/webhook` which expects JSON data. TradingView can be configured to send alerts to `http://<your-server-ip>:5000/webhook`.
+
+Whenever an alert is received the server simply prints the JSON payload to the
+console. This allows you to see incoming TradingView alerts without any extra
+configuration.
+
+## Testing
+
+Run the automated tests with `pytest`:
+
+```bash
+pytest
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask==2.3.2
+Werkzeug<3.0
+pytest==7.4.0

--- a/server.py
+++ b/server.py
@@ -1,0 +1,22 @@
+import json
+from flask import Flask, request, jsonify
+
+app = Flask(__name__)
+
+
+def handle_alert(data: dict) -> None:
+    """Process the alert by printing it to the console."""
+    print(f"Received alert: {json.dumps(data)}")
+
+
+@app.route('/webhook', methods=['POST'])
+def webhook():
+    data = request.get_json(silent=True)
+    if data is None:
+        return jsonify({'error': 'Invalid JSON'}), 400
+    handle_alert(data)
+    return jsonify({'received': data}), 200
+
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,13 @@
+import os
+import sys
+import pytest
+
+# ensure server module can be imported when tests are run from repo root
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from server import app
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    with app.test_client() as client:
+        yield client

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -1,0 +1,30 @@
+import json
+import server
+
+
+class Dummy:
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, *args, **kwargs):
+        self.calls.append((args, kwargs))
+
+
+def test_webhook(client, monkeypatch):
+    dummy = Dummy()
+    monkeypatch.setattr(server, "handle_alert", dummy)
+    response = client.post('/webhook', json={'foo': 'bar'})
+    assert response.status_code == 200
+    data = json.loads(response.data.decode())
+    assert data['received'] == {'foo': 'bar'}
+    assert dummy.calls, "handle_alert should be called"
+
+def test_webhook_echo(client):
+    response = client.post('/webhook', json={'foo': 'bar'})
+    assert response.status_code == 200
+    data = json.loads(response.data.decode())
+    assert data['received'] == {'foo': 'bar'}
+
+def test_invalid_json(client):
+    response = client.post('/webhook', data='notjson', headers={'Content-Type': 'application/json'})
+    assert response.status_code == 400


### PR DESCRIPTION
## Summary
- strip email functionality from server
- print alert payloads to console
- simplify README setup instructions
- update tests to patch `handle_alert`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68483864f4588330bad3dd0b1b7b327b