### PR TITLE
Simplify webhook to just log alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,15 +22,9 @@ python server.py
 
 The server listens on port `5000` and exposes a single POST endpoint `/webhook` which expects JSON data. TradingView can be configured to send alerts to `http://<your-server-ip>:5000/webhook`.
 
-The endpoint forwards the alert to configured email addresses using SMTP. You
-can use Gmail or any other SMTP provider. Configuration is done through
-environment variables:
-
-- `ALERT_EMAILS`: comma separated list of recipient emails
-- `SMTP_SERVER`, `SMTP_PORT`, `SMTP_USERNAME`, `SMTP_PASSWORD`, `EMAIL_FROM`:
-  SMTP credentials for sending mail
-
-If any of the email variables are missing the message will not be sent.
+Every incoming alert is printed to the console, allowing you to verify that the
+server is receiving data correctly. This example does not send emails or
+forward the alert anywhere else.
 
 ## Testing
 

--- a/server.py
+++ b/server.py
@@ -1,35 +1,8 @@
-import os
 import json
-import smtplib
-from email.mime.text import MIMEText
 from flask import Flask, request, jsonify
-
-EMAIL_RECIPIENTS = [e.strip() for e in os.getenv('ALERT_EMAILS', '').split(',') if e.strip()]
 
 app = Flask(__name__)
 
-
-def send_email(subject: str, body: str) -> None:
-    """Send an email using SMTP if configuration is present."""
-    if not EMAIL_RECIPIENTS:
-        return
-    smtp_server = os.getenv('SMTP_SERVER')
-    smtp_port = int(os.getenv('SMTP_PORT', '587'))
-    smtp_user = os.getenv('SMTP_USERNAME')
-    smtp_password = os.getenv('SMTP_PASSWORD')
-    email_from = os.getenv('EMAIL_FROM')
-    if not all([smtp_server, smtp_user, smtp_password, email_from]):
-        return
-
-    msg = MIMEText(body)
-    msg['Subject'] = subject
-    msg['From'] = email_from
-    msg['To'] = ', '.join(EMAIL_RECIPIENTS)
-
-    with smtplib.SMTP(smtp_server, smtp_port) as smtp:
-        smtp.starttls()
-        smtp.login(smtp_user, smtp_password)
-        smtp.sendmail(email_from, EMAIL_RECIPIENTS, msg.as_string())
 
 @app.route('/webhook', methods=['POST'])
 def webhook():
@@ -37,7 +10,8 @@ def webhook():
     if data is None:
         return jsonify({'error': 'Invalid JSON'}), 400
     body = json.dumps(data)
-    send_email('TradingView Alert', body)
+    # Print the alert payload so it appears in the console logs
+    print(f"Received alert: {body}")
     return jsonify({'received': data}), 200
 
 if __name__ == '__main__':

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -2,24 +2,7 @@ import json
 import server
 
 
-class Dummy:
-    def __init__(self):
-        self.calls = []
-
-    def __call__(self, *args, **kwargs):
-        self.calls.append((args, kwargs))
-
-
-def test_webhook(client, monkeypatch):
-    email_dummy = Dummy()
-    monkeypatch.setattr(server, "send_email", email_dummy)
-    response = client.post('/webhook', json={'foo': 'bar'})
-    assert response.status_code == 200
-    data = json.loads(response.data.decode())
-    assert data['received'] == {'foo': 'bar'}
-    assert email_dummy.calls, "send_email should be called"
-
-def test_webhook_echo(client):
+def test_webhook(client):
     response = client.post('/webhook', json={'foo': 'bar'})
     assert response.status_code == 200
     data = json.loads(response.data.decode())
@@ -28,3 +11,15 @@ def test_webhook_echo(client):
 def test_invalid_json(client):
     response = client.post('/webhook', data='notjson', headers={'Content-Type': 'application/json'})
     assert response.status_code == 400
+
+
+def test_webhook_prints_to_console(client, monkeypatch):
+    printed = []
+
+    def fake_print(*args, **kwargs):
+        printed.append(' '.join(str(a) for a in args))
+
+    monkeypatch.setattr('builtins.print', fake_print)
+    response = client.post('/webhook', json={'foo': 'bar'})
+    assert response.status_code == 200
+    assert any('Received alert' in p for p in printed)


### PR DESCRIPTION
## Summary
- strip out email features to keep webhook minimal
- document that alerts are only printed
- update tests for the new simple behavior

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6860c98841008330b02a1c5d543fa7b7